### PR TITLE
Add PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We provide examples for the languages:
 - [F#](./fs/)
 - [Go](./go/)
 - [Python](./py/)
+- [PHP](./php/)
 
 However, we always welcome to add examples for other languages above.
 Feel free to send a pull request.

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,11 @@
+Code Examples for PHP
+----------------------------
+
+* System under test: [`FooBarUser.php`](./example/FooBarUser.php)
+* Depended-on Component:
+    * [`Foo.php`](./example/Foo.php)
+    * [`Bar.php`](./example/Bar.php)
+* Tests: [`tests/FooBarTest.php`](./example/tests/FooBarTest.php)
+* Test Doubles ([Vanilla Mocks](https://github.com/vanilla-manifesto/vanilla-mock-manifesto)):
+    * [`FooStub.php`](./example/FooStub.php)
+    * [`BarSpy.php`](./example/BarSpy.php)

--- a/php/example/Bar.php
+++ b/php/example/Bar.php
@@ -1,0 +1,16 @@
+<?php
+
+interface Bar
+{
+    function doSomething(int $value);
+}
+
+
+// The name of concrete classes should represent its behavior.
+// For example, this class do nothing, so we can name it as "-Null".
+// But you can still name as "-Impl" or "-Default" if there are no ways.
+class BarNull implements Bar
+{
+    function doSomething(int $value)
+    {}
+}

--- a/php/example/BarSpy.php
+++ b/php/example/BarSpy.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once 'Bar.php';
+
+class BarSpy implements Bar
+{
+
+    public $callArgs = [];
+
+    function doSomething(int $value)
+    {
+        array_push($this->callArgs, $value);
+    }
+}

--- a/php/example/Foo.php
+++ b/php/example/Foo.php
@@ -1,0 +1,17 @@
+<?php
+
+interface Foo
+{
+    function getSomething(): int;
+}
+
+
+// The name of concrete classes should represent its behavior.
+// For example, this class return always 42, so we can name it as "-Const".
+// But you can still name as "-Impl" or "-Default" if there are no ways.
+class FooConst implements Foo
+{
+    function getSomething(): int {
+        return 42;
+    }
+}

--- a/php/example/FooBarUser.php
+++ b/php/example/FooBarUser.php
@@ -1,0 +1,29 @@
+<?php
+
+class Dependency
+{
+    public Foo $foo;
+    public Bar $bar;
+
+    function __construct(Foo $foo, Bar $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+}
+
+class FooBarUser
+{
+    private Dependency $dependency;
+
+    function __construct(Dependency $dependency)
+    {
+        $this->dependency = $dependency;
+    }
+
+    function danceWithDependancies ()
+    {
+        list($foo, $bar) = [$this->dependency->foo, $this->dependency->bar];
+        $bar->doSomething($foo->getSomething());
+    }
+}

--- a/php/example/FooStub.php
+++ b/php/example/FooStub.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once 'Foo.php';
+
+class FooStub implements Foo
+{
+    private int $nextValue;
+
+    function __construct(int $firstValue)
+    {
+        $this->nextValue = $firstValue;
+    }
+
+    function getSomething(): int
+    {
+        return $this->nextValue;
+    }
+}

--- a/php/example/tests/FooBarTest.php
+++ b/php/example/tests/FooBarTest.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once dirname(__FILE__).'/../FooBarUser.php';
+require_once dirname(__FILE__).'/../Foo.php';
+require_once dirname(__FILE__).'/../Bar.php';
+
+require_once dirname(__FILE__).'/../FooStub.php';
+require_once dirname(__FILE__).'/../BarSpy.php';
+
+
+$tests = new FooBarTest();
+$tests->testFooBar();
+$tests->testProduction();
+
+
+class FooBarTest {
+
+    function testFooBar()
+    {
+        $barSpy = new BarSpy();
+
+        $fooBarUser = new FooBarUser(
+            new Dependency(
+                new FooStub(1234),
+                $barSpy
+            )
+        );
+
+        $fooBarUser->danceWithDependancies();
+
+        assert($barSpy->callArgs == [1234]);
+    }
+
+    function testProduction()
+    {
+        $fooBarUser = new FooBarUser(
+            new Dependency(
+                new FooConst(),
+                new BarNull()
+            )
+        );
+
+        $fooBarUser->danceWithDependancies();
+    }
+
+}


### PR DESCRIPTION
Added example in PHP.
You can do it with PHP 7.4.
(Because I use the function of 7.4, I think that errors will occur in ver before that.)

---
(translation for Japanese)

PHP での example を追加しました。
PHP 7.4 で実行できます。
(7.4 の機能を利用している為、それ以前のver ではエラーが出ると思います。)